### PR TITLE
Support string queries

### DIFF
--- a/spec/fixtures/plugins/builders/test_queries.rb
+++ b/spec/fixtures/plugins/builders/test_queries.rb
@@ -15,6 +15,17 @@ class TestQueries < SiteBuilder
     }
   end
 
+  graphql :somethings_string, <<-GRAPHQL
+    query {
+      somethings {
+        identifier: id
+        title
+        age
+        createdAt
+      }
+    }
+  GRAPHQL
+
   def build
     queries.somethings.each do |something|
       slug = Bridgetown::Utils.slugify(something.title)
@@ -23,6 +34,16 @@ class TestQueries < SiteBuilder
         date something.created_at
         front_matter something.to_h
         content "My **age** is #{something.age}"
+      end
+    end
+
+    queries.somethings_string.somethings.each do |something|
+      slug = Bridgetown::Utils.slugify(something.title)
+      doc "#{slug}-string.md" do
+        layout "post"
+        date something.created_at
+        front_matter something.to_h.merge(title: something.title + "-string")
+        content "My string **age** is #{something.age}"
       end
     end
   end
@@ -39,12 +60,17 @@ class TestQueries < SiteBuilder
           }
         ]
       },
-    }.to_json
+    }
 
     lambda do |env|
       query_input = env["rack.input"].read
-      raise "Invalid GraphQL query input" unless query_input.include?("{\\n  somethings {\\n    id\\n    title\\n    age\\n    createdAt\\n  }")
-      [200, {'Content-Type' => 'application/json'}, [json_response]]
+      raise "Invalid GraphQL query input" unless query_input =~ /{\\n  somethings {\\n    (identifier: )?id\\n    title\\n    age\\n    createdAt\\n  }/
+
+      if query_input.include?('identifier')
+        json_response[:data][:somethings].first[:identifier] = 1
+        json_response[:data][:somethings].first.delete(:id)
+      end
+      [200, {'Content-Type' => 'application/json'}, [json_response.to_json]]
     end
   end
 

--- a/spec/graphtown_spec.rb
+++ b/spec/graphtown_spec.rb
@@ -32,5 +32,6 @@ describe(Graphtown) do
 
   it "outputs posts loaded via GraphQL" do
     expect(contents).to match "<div>I'm a title! / 123</div>"
+    expect(contents).to match "<div>I'm a title!-string / 123</div>"
   end
 end


### PR DESCRIPTION
This allows the user to specify attribute aliases when the default block version does not.

```ruby
  graphql :somethings, <<-GRAPHQL
    query {
      somethings {
        identifier: id
        title
        userAge: age
        date: createdAt
      }
    }
  GRAPHQL
```

cc @jaredcwhite 